### PR TITLE
[FIX] group/post_list 404 예외처리

### DIFF
--- a/group/views.py
+++ b/group/views.py
@@ -823,7 +823,7 @@ def post_list(request, pk):
         return redirect('user:main')
 
     posts = GroupPost.objects.filter(group__pk=pk).order_by('-created_at')
-    group = Group.objects.get(pk=pk)
+    group = get_object_or_404(Group, pk=pk)
     page = request.GET.get('page', '1')    # 페이지
 
     # ismember


### PR DESCRIPTION
group = Group.objects.get(pk=pk)
을 
    group = get_object_or_404(Group, pk=pk)
로 수정함으로써
사용자가 존재하지 않는 리소스에 대해서 요청을 보냈을 때
500 에러가 아닌 404 에러가 뜨도록 함